### PR TITLE
Support the `http` language tag on code blocks when detecting HTTP request format

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -110,7 +110,7 @@ let defaultFileTypes = {
       {
         name: "httpRequestFormat",
         regex: [
-          "```\\n([A-Z]+)\\s+([^\\s]+)(?:\\s+HTTP\\/[\\d.]+)?\\r?\\n((?:[^\\r\\n]+(?:\\r?\\n|$))*)(?:\\r?\\n([\\s\\S]*))?\\n```",
+          "```(?:http)\\n([A-Z]+)\\s+([^\\s]+)(?:\\s+HTTP\\/[\\d.]+)?\\r?\\n((?:[^\\r\\n]+(?:\\r?\\n|$))*)(?:\\r?\\n([\\s\\S]*))?\\n```",
         ],
         actions: [
           {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of HTTP request code blocks in markdown by only matching blocks explicitly labeled as "http". This ensures more accurate formatting and parsing of HTTP examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->