### PR TITLE
Allow "unsafe" step and test markup, and add new runCode markup for markdown

### DIFF
--- a/.github/workflows/update-common.yaml
+++ b/.github/workflows/update-common.yaml
@@ -58,16 +58,35 @@ jobs:
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
 
-    - name: Bump patch version
+    - name: Bump or sync version
       id: patch
       if: steps.commit.outputs.has_changes == 'true'
       run: |
         git checkout -- .
         git clean -fd
-        npm version patch
+        # Get current project version
+        PROJ_VERSION=$(node -p "require('./package.json').version")
+        # Get doc-detective-common version (strip ^ or ~)
+        COMMON_VERSION=$(node -p "(require('./package.json').dependencies['doc-detective-common'] || require('./package.json').devDependencies['doc-detective-common'] || '').replace(/^[^\\d]*/, '')")
+        # Parse versions
+        PROJ_MAJOR=$(echo $PROJ_VERSION | cut -d. -f1)
+        PROJ_MINOR=$(echo $PROJ_VERSION | cut -d. -f2)
+        COMMON_MAJOR=$(echo $COMMON_VERSION | cut -d. -f1)
+        COMMON_MINOR=$(echo $COMMON_VERSION | cut -d. -f2)
+        if [ "$PROJ_MAJOR" != "$COMMON_MAJOR" ] || [ "$PROJ_MINOR" != "$COMMON_MINOR" ]; then
+          # Major or minor mismatch: set version to match doc-detective-common major.minor.0
+          NEW_VERSION="$COMMON_MAJOR.$COMMON_MINOR.0"
+          npm version --no-git-tag-version "$NEW_VERSION"
+        else
+          # Only patch changed: bump patch
+          npm version patch --no-git-tag-version
+        fi
+        git add package.json package-lock.json
+        git commit -m "bump version to match doc-detective-common"
         git push
+        git tag "v$(node -p \"require('./package.json').version\")"
         git push --tags
-        echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
 
     - name: Create release
       if: steps.commit.outputs.has_changes == 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,37 @@
 {
   "name": "doc-detective-resolver",
-  "version": "3.0.10",
+  "version": "3.1.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-resolver",
-      "version": "3.0.10",
+      "version": "3.1.0-dev.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^13.0.1",
+        "@apidevtools/json-schema-ref-parser": "^13.0.5",
         "ajv": "^8.17.1",
         "axios": "^1.9.0",
-        "doc-detective-common": "^3.0.9",
+        "doc-detective-common": "^3.1.0-dev.0",
         "dotenv": "^16.5.0",
         "json-schema-faker": "^0.5.9",
-        "posthog-node": "^4.18.0",
+        "posthog-node": "^5.1.0",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
         "body-parser": "^2.2.0",
         "chai": "^5.2.0",
         "express": "^5.1.0",
-        "mocha": "^11.5.0",
+        "mocha": "^11.6.0",
         "proxyquire": "^2.1.3",
-        "sinon": "^20.0.0"
+        "sinon": "^21.0.0",
+        "yaml": "^2.8.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-13.0.1.tgz",
-      "integrity": "sha512-91uy6MGWqu7CjcV7tLPMuYh/Wj/RNPBXquSdEaCEpj2H/cFy0Yu+t1EdxExSyaryl1ykhDo30plq9tIm/HVZnw==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-13.0.5.tgz",
+      "integrity": "sha512-xfh4xVJD62gG6spIc7lwxoWT+l16nZu1ELyU8FkjaP/oD2yP09EvLAU6KhtudN9aML2Khhs9pY6Slr7KGTES3w==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
@@ -723,12 +724,12 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-3.0.9.tgz",
-      "integrity": "sha512-6TPXpaSw94Bvih7Quo6bsUwmQe+hnNRjLpQw0T/7NBitp51k1LcY0wp6j7mhMGphA1MS/GdVEnzKm//CpdA1jg==",
+      "version": "3.1.0-dev.0",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-3.1.0-dev.0.tgz",
+      "integrity": "sha512-EfRERuD9FFMngLtA5TvsCCcqcbOxagDx57YheNXt2C12yMx4oAnV+18CeAFDjTFMPjoH3NOioJ6KhUaqxAK3EA==",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^13.0.1",
+        "@apidevtools/json-schema-ref-parser": "^13.0.5",
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",
@@ -1575,9 +1576,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.5.0.tgz",
-      "integrity": "sha512-VKDjhy6LMTKm0WgNEdlY77YVsD49LZnPSXJAaPNL9NRYQADxvORsyG1DIQY6v53BKTnlNbEE2MbVCDbnxr4K3w==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.6.0.tgz",
+      "integrity": "sha512-i0JVb+OUBqw63X/1pC3jCyJsqYisgxySBbsQa8TKvefpA1oEnw7JXxXnftfMHRsw7bEEVGRtVlHcDYXBa7FzVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1597,7 +1598,7 @@
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
+        "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -1804,15 +1805,12 @@
       "license": "ISC"
     },
     "node_modules/posthog-node": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-4.18.0.tgz",
-      "integrity": "sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.1.0.tgz",
+      "integrity": "sha512-U+b2GJEhK1O0BuIdsoYJu3M+3OUZIbQAhAmIYHTMTCaA7dFx30Pv1nXqA4gPjEPoXhXc6akJbMTRREY5ncJ/Gw==",
       "license": "MIT",
-      "dependencies": {
-        "axios": "^1.8.2"
-      },
       "engines": {
-        "node": ">=15.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/proxy-addr": {
@@ -2177,9 +2175,9 @@
       }
     },
     "node_modules/sinon": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
-      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2451,10 +2449,11 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-      "dev": true
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.2.tgz",
+      "integrity": "sha512-Xz4Nm9c+LiBHhDR5bDLnNzmj6+5F+cyEAWPMkbs2awq/dYazR/efelZzUAjB/y3kNHL+uzkHvxVVpaOfGCPV7A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "doc-detective-resolver",
-  "version": "3.1.0-dev.0",
+  "version": "3.1.0-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-resolver",
-      "version": "3.1.0-dev.0",
+      "version": "3.1.0-dev.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^13.0.5",
         "ajv": "^8.17.1",
         "axios": "^1.9.0",
-        "doc-detective-common": "^3.1.0-dev.0",
+        "doc-detective-common": "^3.1.0-dev.1",
         "dotenv": "^16.5.0",
         "json-schema-faker": "^0.5.9",
         "posthog-node": "^5.1.0",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "3.1.0-dev.0",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-3.1.0-dev.0.tgz",
-      "integrity": "sha512-EfRERuD9FFMngLtA5TvsCCcqcbOxagDx57YheNXt2C12yMx4oAnV+18CeAFDjTFMPjoH3NOioJ6KhUaqxAK3EA==",
+      "version": "3.1.0-dev.1",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-3.1.0-dev.1.tgz",
+      "integrity": "sha512-p6nm6GktsGW2yeXMh6AZezQKUy11JQZu1CHBwDEcnBv4OKGwm6srtlRY9fIM6Kb1J8wqzAWsTqs0wPfofP6+rA==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^13.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-resolver",
-  "version": "3.0.10",
+  "version": "3.1.0-dev.0",
   "description": "Detect and resolve docs into Doc Detective tests.",
   "main": "src/index.js",
   "scripts": {
@@ -24,21 +24,22 @@
   },
   "homepage": "https://github.com/doc-detective/doc-detective-core#readme",
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^13.0.1",
+    "@apidevtools/json-schema-ref-parser": "^13.0.5",
     "ajv": "^8.17.1",
     "axios": "^1.9.0",
-    "doc-detective-common": "^3.0.9",
+    "doc-detective-common": "^3.1.0-dev.0",
     "dotenv": "^16.5.0",
     "json-schema-faker": "^0.5.9",
-    "posthog-node": "^4.18.0",
+    "posthog-node": "^5.1.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
     "body-parser": "^2.2.0",
     "chai": "^5.2.0",
     "express": "^5.1.0",
-    "mocha": "^11.5.0",
+    "mocha": "^11.6.0",
     "proxyquire": "^2.1.3",
-    "sinon": "^20.0.0"
+    "sinon": "^21.0.0",
+    "yaml": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-resolver",
-  "version": "3.1.0-dev.0",
+  "version": "3.1.0-dev.2",
   "description": "Detect and resolve docs into Doc Detective tests.",
   "main": "src/index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "@apidevtools/json-schema-ref-parser": "^13.0.5",
     "ajv": "^8.17.1",
     "axios": "^1.9.0",
-    "doc-detective-common": "^3.1.0-dev.0",
+    "doc-detective-common": "^3.1.0-dev.1",
     "dotenv": "^16.5.0",
     "json-schema-faker": "^0.5.9",
     "posthog-node": "^5.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -127,7 +127,7 @@ let defaultFileTypes = {
       },
       {
         name: "runCode",
-        regex: ["```(bash|python|py|javascript|js)(?!.*testIgnore).*?\\r?\\n([\\s\\S]*?)\\r?\\n```"],
+        regex: ["```(bash|python|py|javascript|js)(?![^\\r\\n]*testIgnore)\\s[^\\r\\n]*\\r?\\n([\\s\\S]*?)\\r?\\n```"],
         actions: [
           {
             unsafe: true,

--- a/src/config.js
+++ b/src/config.js
@@ -217,19 +217,13 @@ async function setConfig({ config }) {
   config.fileTypes = config.fileTypes.map((fileType) => {
     if (fileType.inlineStatements) {
       if (typeof fileType.inlineStatements.testStart === "string")
-        fileType.inlineStatements.testStart = [
-          fileType.inlineStatements.testStart,
-        ];
+        fileType.inlineStatements.testStart = [fileType.inlineStatements.testStart];
       if (typeof fileType.inlineStatements.testEnd === "string")
         fileType.inlineStatements.testEnd = [fileType.inlineStatements.testEnd];
       if (typeof fileType.inlineStatements.ignoreStart === "string")
-        fileType.inlineStatements.ignoreStart = [
-          fileType.inlineStatements.ignoreStart,
-        ];
+        fileType.inlineStatements.ignoreStart = [fileType.inlineStatements.ignoreStart];
       if (typeof fileType.inlineStatements.ignoreEnd === "string")
-        fileType.inlineStatements.ignoreEnd = [
-          fileType.inlineStatements.ignoreEnd,
-        ];
+        fileType.inlineStatements.ignoreEnd = [fileType.inlineStatements.ignoreEnd];
       if (typeof fileType.inlineStatements.step === "string")
         fileType.inlineStatements.step = [fileType.inlineStatements.step];
     }
@@ -241,7 +235,18 @@ async function setConfig({ config }) {
     }
     if (fileType.extends) {
       // If fileType extends another, merge the properties
-      const extendedFileType = defaultFileTypes[fileType.extends];
+      const extendedFileTypeRaw = defaultFileTypes[fileType.extends];
+      if (!extendedFileTypeRaw) {
+        log(
+          config,
+          "error",
+          'Invalid config. fileType.extends references unknown fileType definition: "' + fileType.extends + '".'
+        );
+        throw new Error(
+          'Invalid config. fileType.extends references unknown fileType definition: "' + fileType.extends + '".'
+        );
+      }
+      const extendedFileType = JSON.parse(JSON.stringify(extendedFileTypeRaw));
       if (extendedFileType) {
         if (!fileType.name) {
           fileType.name = extendedFileType.name;

--- a/src/config.js
+++ b/src/config.js
@@ -165,7 +165,7 @@ let defaultFileTypes = {
       {
         name: "runCode",
         regex: [
-          "```(bash|python|py|javascript|js)(?![^\\r\\n]*testIgnore)\\s[^\\r\\n]*\\r?\\n([\\s\\S]*?)\\r?\\n```",
+          "```(bash|python|py|javascript|js)(?![^\\r\\n]*testIgnore)[^\\r\\n]*\\r?\\n([\\s\\S]*?)\\r?\\n```",
         ],
         actions: [
           {

--- a/src/config.js
+++ b/src/config.js
@@ -126,13 +126,13 @@ let defaultFileTypes = {
         ],
       },
       {
-        unsafe: true,
-        // This is unsafe because it runs arbitrary code, so it should be used with caution.
-        // It is recommended to use this only in trusted environments or with trusted inputs.
         name: "runCode",
         regex: ["```(bash|python|py|javascript|js)(?!.*testIgnore).*?\\r?\\n([\\s\\S]*?)\\r?\\n```"],
         actions: [
           {
+            unsafe: true,
+            // This is unsafe because it runs arbitrary code, so it should be used with caution.
+            // It is recommended to use this only in trusted environments or with trusted inputs.
             runCode: {
               language: "$1",
               code: "$2",

--- a/src/config.js
+++ b/src/config.js
@@ -125,19 +125,21 @@ let defaultFileTypes = {
           },
         ],
       },
-      // {
-      //   name: "runBash",
-      //   regex: ["```(?:bash)\\b\\s*\\n(?<code>.*?)(?=\\n```)"],
-      //   batchMatches: true,
-      //   actions: [
-      //     {
-      //       runCode: {
-      //         language: "bash",
-      //         code: "$1",
-      //       },
-      //     },
-      //   ],
-      // },
+      {
+        unsafe: true,
+        // This is unsafe because it runs arbitrary code, so it should be used with caution.
+        // It is recommended to use this only in trusted environments or with trusted inputs.
+        name: "runCode",
+        regex: ["```(bash|python|py|javascript|js)(?!.*testIgnore).*?\\r?\\n([\\s\\S]*?)\\r?\\n```"],
+        actions: [
+          {
+            runCode: {
+              language: "$1",
+              code: "$2",
+            },
+          },
+        ],
+      },
     ],
   },
 };
@@ -233,7 +235,7 @@ async function setConfig({ config }) {
     }
     if (fileType.markup) {
       fileType.markup = fileType.markup.map((markup) => {
-        if (typeof markup.regex === "string") markup.regex = [markup.regex];
+        if (typeof markup?.regex === "string") markup.regex = [markup.regex];
         return markup;
       });
     }
@@ -247,12 +249,12 @@ async function setConfig({ config }) {
 
         // Merge extensions
         if (extendedFileType?.extensions) {
-            fileType.extensions = [
+          fileType.extensions = [
             ...new Set([
               ...(extendedFileType.extensions || []),
               ...(fileType.extensions || []),
             ]),
-            ];
+          ];
         }
 
         // Merge property values for inlineStatements children
@@ -260,27 +262,27 @@ async function setConfig({ config }) {
           if (fileType.inlineStatements === undefined) {
             fileType.inlineStatements = {};
           }
-            // Merge each inlineStatements property using Set to ensure uniqueness
-            const keys = [
+          // Merge each inlineStatements property using Set to ensure uniqueness
+          const keys = [
             "testStart",
             "testEnd",
             "ignoreStart",
             "ignoreEnd",
             "step",
-            ];
-            for (const key of keys) {
+          ];
+          for (const key of keys) {
             if (
               extendedFileType?.inlineStatements?.[key] ||
               fileType?.inlineStatements?.[key]
             ) {
               fileType.inlineStatements[key] = [
-              ...new Set([
-                ...(extendedFileType?.inlineStatements?.[key] || []),
-                ...(fileType?.inlineStatements?.[key] || []),
-              ]),
+                ...new Set([
+                  ...(extendedFileType?.inlineStatements?.[key] || []),
+                  ...(fileType?.inlineStatements?.[key] || []),
+                ]),
               ];
             }
-            }
+          }
         }
 
         // Merge property values for markup array, overwriting when `name` matches

--- a/src/config.js
+++ b/src/config.js
@@ -237,28 +237,20 @@ async function setConfig({ config }) {
   }
   config = validityCheck.object;
 
-  // Set default values for missing properties
-  config = {
-    fileTypes: [],
-    ...config,
-  };
-
   // Replace fileType strings with objects
-  if (config?.fileTypes) {
-    config.fileTypes = config.fileTypes.map((fileType) => {
-      if (typeof fileType === "object") return fileType;
-      const fileTypeObject = defaultFileTypes[fileType];
-      if (typeof fileTypeObject !== "undefined") return fileTypeObject;
-      log(
-        config,
-        "error",
-        `Invalid config. "${fileType}" isn't a valid fileType value.`
-      );
-      throw new Error(
-        `Invalid config. "${fileType}" isn't a valid fileType value.`
-      );
-    });
-  }
+  config.fileTypes = config.fileTypes.map((fileType) => {
+    if (typeof fileType === "object") return fileType;
+    const fileTypeObject = defaultFileTypes[fileType];
+    if (typeof fileTypeObject !== "undefined") return fileTypeObject;
+    log(
+      config,
+      "error",
+      `Invalid config. "${fileType}" isn't a valid fileType value.`
+    );
+    throw new Error(
+      `Invalid config. "${fileType}" isn't a valid fileType value.`
+    );
+  });
 
   // TODO: Combine extended fileTypes with overrides
 

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -1,0 +1,185 @@
+const { setConfig } = require("./config");
+const path = require("path");
+
+before(async function () {
+  const { expect } = await import("chai");
+  global.expect = expect;
+});
+
+describe("Config tests", async function () {
+  // Test that config is resolved correctly
+  it("Config is resolved correctly", async function () {
+    const configSets = [
+      //   {
+      //     config: { input: "input.spec.json" },
+      //     expected: { input: ["input.spec.json"] },
+      //   },
+      //   {
+      //     config: { input: ["input.spec.json", "input2.spec.json"] },
+      //     expected: {
+      //       input: [
+      //         "input.spec.json",
+      //         "input2.spec.json",
+      //       ],
+      //     },
+      //   },
+      //   {
+      //     config: { input: ["input.spec.json", "input2.spec.json"], output: "." },
+      //     expected: {
+      //       input: [
+      //         "input.spec.json",
+      //         "input2.spec.json",
+      //       ],
+      //       output: ".",
+      //     },
+      //   },
+      {
+        config: {
+          fileTypes: [
+            {
+              extends: "markdown",
+              markup: [
+                {
+                  name: "runBash",
+                  regex: ["```(?:bash)\\b\\s*\\n(?<code>.*?)(?=\\n```)"],
+                  batchMatches: true,
+                  actions: [
+                    {
+                      runCode: {
+                        language: "bash",
+                        code: "$1",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        expected: {
+          fileTypes: [
+            {
+              name: "markdown",
+            },
+          ],
+        },
+      },
+    ];
+
+    for (const configSet of configSets) {
+      // Set config with the configSet
+      console.log(`Config test: ${JSON.stringify(configSet, null, 2)}`);
+      const config = await setConfig({ config: configSet.config });
+      expect(config).to.be.an("object");
+      console.log(`Config result: ${JSON.stringify(config, null, 2)}\n`);
+      // Deeply compare the config result with the expected result
+      deepObjectExpect(config, configSet.expected);
+    }
+  });
+});
+
+describe("File type tests", async function () {
+  // Test that file types are resolved correctly
+  it("File types resolve correctly", async function () {
+    const customConfig = {
+      fileTypes: [
+        {
+          name: "myMarkdown",
+          extends: "markdown",
+          extensions: ["md", "markdown", "mkd"], // "mkd" isn't a standard extension, but included for testing
+          inlineStatements: {
+            testStart: [".*?"],
+            testEnd: ".*?",
+          },
+          markup: [
+            {
+              name: "runBash",
+              regex: ["```(?:bash)\\b\\s*\\n(?<code>.*?)(?=\\n```)"],
+              batchMatches: true,
+              actions: [
+                {
+                  runCode: {
+                    language: "bash",
+                    code: "$1",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    console.log(
+      `Custom config: ${JSON.stringify(customConfig, null, 2)}`
+    );
+    const config = await setConfig({ config: customConfig });
+    console.log(`Config result: ${JSON.stringify(config, null, 2)}\n`);
+    // Check that the config has the expected structure
+    expect(config).to.be.an("object");
+    expect(config.fileTypes).to.be.an("array").that.is.not.empty;
+    const markdownType = config.fileTypes.find(
+      (type) => type.name === "myMarkdown"
+    );
+    expect(markdownType).to.exist;
+    expect(markdownType).to.have.property("name").that.equals("myMarkdown");
+    expect(markdownType)
+      .to.have.property("extensions")
+      .that.includes.members(["md", "markdown", "mkd"]);
+    expect(markdownType).to.have.property("inlineStatements").that.has.property("testStart").that.includes.members([".*?"]);
+    expect(markdownType).to.have.property("inlineStatements").that.has.property("testEnd").that.includes.members([".*?"]);
+    expect(markdownType.markup).to.be.an("array").that.is.not.empty;
+    const runBash = markdownType.markup.find(
+      (markup) => markup.name === "runBash"
+    );
+    expect(runBash).to.be.an("object");
+    expect(runBash).to.have.property("regex").that.is.an("array").that.is.not
+      .empty;
+    expect(runBash.regex[0]).to.equal(
+      "```(?:bash)\\b\\s*\\n(?<code>.*?)(?=\\n```)"
+    );
+  });
+});
+
+// Deeply compares two objects
+function deepObjectExpect(actual, expected) {
+  // Check that actual has all the keys of expected
+  Object.entries(expected).forEach(([key, value]) => {
+    // Make sure the property exists in actual
+    expect(actual).to.have.property(key);
+
+    // If value is null, check directly
+    if (value === null) {
+      expect(actual[key]).to.equal(null);
+    }
+    // If value is an array, check each item
+    else if (Array.isArray(value)) {
+      expect(Array.isArray(actual[key])).to.equal(
+        true,
+        `Expected ${key} to be an array. Expected: ${expected[key]}. Actual: ${actual[key]}.`
+      );
+      expect(actual[key].length).to.equal(
+        value.length,
+        `Expected ${key} array to have length ${value.length}. Actual: ${actual[key].length}`
+      );
+
+      // Check each array item
+      value.forEach((item, index) => {
+        if (typeof item === "object" && item !== null) {
+          deepObjectExpect(actual[key][index], item);
+        } else {
+          expect(actual[key][index]).to.equal(item);
+        }
+      });
+    }
+    // If value is an object but not null, recursively check it
+    else if (typeof value === "object") {
+      deepObjectExpect(actual[key], expected[key]);
+    }
+    // Otherwise, check that the value is correct
+    else {
+      const expectedObject = {};
+      expectedObject[key] = value;
+      expect(actual).to.deep.include(expectedObject);
+    }
+  });
+}

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -10,49 +10,34 @@ describe("Config tests", async function () {
   // Test that config is resolved correctly
   it("Config is resolved correctly", async function () {
     const configSets = [
-      //   {
-      //     config: { input: "input.spec.json" },
-      //     expected: { input: ["input.spec.json"] },
-      //   },
-      //   {
-      //     config: { input: ["input.spec.json", "input2.spec.json"] },
-      //     expected: {
-      //       input: [
-      //         "input.spec.json",
-      //         "input2.spec.json",
-      //       ],
-      //     },
-      //   },
-      //   {
-      //     config: { input: ["input.spec.json", "input2.spec.json"], output: "." },
-      //     expected: {
-      //       input: [
-      //         "input.spec.json",
-      //         "input2.spec.json",
-      //       ],
-      //       output: ".",
-      //     },
-      //   },
+        // {
+        //   config: { input: "input.spec.json" },
+        //   expected: { input: ["input.spec.json"] },
+        // },
+        // {
+        //   config: { input: ["input.spec.json", "input2.spec.json"] },
+        //   expected: {
+        //     input: [
+        //       "input.spec.json",
+        //       "input2.spec.json",
+        //     ],
+        //   },
+        // },
+        // {
+        //   config: { input: ["input.spec.json", "input2.spec.json"], output: "." },
+        //   expected: {
+        //     input: [
+        //       "input.spec.json",
+        //       "input2.spec.json",
+        //     ],
+        //     output: ".",
+        //   },
+        // },
       {
         config: {
           fileTypes: [
             {
               extends: "markdown",
-              markup: [
-                {
-                  name: "runBash",
-                  regex: ["```(?:bash)\\b\\s*\\n(?<code>.*?)(?=\\n```)"],
-                  batchMatches: true,
-                  actions: [
-                    {
-                      runCode: {
-                        language: "bash",
-                        code: "$1",
-                      },
-                    },
-                  ],
-                },
-              ],
             },
           ],
         },

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -6,7 +6,7 @@ before(async function () {
   global.expect = expect;
 });
 
-describe("Config tests", async function () {
+describe("Config tests", function () {
   // Test that config is resolved correctly
   it("Config is resolved correctly", async function () {
     const configSets = [
@@ -63,7 +63,7 @@ describe("Config tests", async function () {
   });
 });
 
-describe("File type tests", async function () {
+describe("File type tests", function () {
   // Test that file types are resolved correctly
   it("File types resolve correctly", async function () {
     const customConfig = {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -191,6 +191,28 @@ const markdownInput = `
 ![Search results.](reference.png)
 `;
 
+const codeInMarkdown = `
+\`\`\`bash
+# This is a bash code block
+echo "Hello, World!"
+\`\`\`
+
+\`\`\`javascript
+// This is a JavaScript code block
+console.log("Hello, World!");
+\`\`\`
+
+\`\`\`python
+# This is a Python code block
+print("Hello, World!")
+\`\`\`
+
+\`\`\`bash testIgnore
+# This is a bash code block that should be ignored
+echo "This should not be detected as a test step"
+\`\`\`
+`;
+
 describe("Input/output detect comparisons", async function () {
   it("should correctly parse YAML input", async function () {
     // Create temp yaml file
@@ -249,5 +271,20 @@ describe("Input/output detect comparisons", async function () {
     expect(results.specs[0].tests).to.be.an("array").that.has.lengthOf(1);
     expect(results.specs[0].tests[0].contexts).to.be.an("array").that.has.lengthOf(1);
     expect(results.specs[0].tests[0].contexts[0].steps).to.be.an("array").that.has.lengthOf(11);
+  });
+
+  it("should correctly parse code in markdown input", async function () {
+    // Create temp markdown file
+    const tempMarkdownFile = "temp_code.md";
+    fs.writeFileSync(tempMarkdownFile, codeInMarkdown.trim());
+    const config = {
+      input: tempMarkdownFile,
+    };
+    const results = await detectAndResolveTests({ config });
+    fs.unlinkSync(tempMarkdownFile); // Clean up temp file
+    expect(results.specs).to.be.an("array").that.has.lengthOf(1);
+    expect(results.specs[0].tests).to.be.an("array").that.has.lengthOf(1);
+    expect(results.specs[0].tests[0].contexts).to.be.an("array").that.has.lengthOf(1);
+    expect(results.specs[0].tests[0].contexts[0].steps).to.be.an("array").that.has.lengthOf(3);
   });
 });

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -214,6 +214,7 @@ async function resolveContext({ config, test, context }) {
   log(config, "debug", `CONTEXT: ${contextId}`);
   const resolvedContext = {
     ...context,
+    unsafe: test.unsafe || false,
     openApi: test.openApi || [],
     steps: [...test.steps],
     contextId: contextId,

--- a/src/utils.js
+++ b/src/utils.js
@@ -584,9 +584,6 @@ async function parseContent({ config, content, filePath, fileType }) {
   });
 
   tests.forEach((test) => {
-    // If any steps are unsafe, mark the test as unsafe
-    test.unsafe = isUnsafe({ stepArray: test.steps });
-
     // Validate test object
     const validation = validate({
       schemaKey: "test_v3",
@@ -602,6 +599,9 @@ async function parseContent({ config, content, filePath, fileType }) {
       return false;
     }
     test = validation.object;
+    // If any steps are unsafe, mark the test as unsafe
+    test.unsafe = isUnsafe({ stepArray: test.steps });
+    
   });
 
   return tests;

--- a/src/utils.js
+++ b/src/utils.js
@@ -394,7 +394,7 @@ async function parseContent({ config, content, filePath, fileType }) {
             sortIndex: Math.min(...matches.map((match) => match.index)),
           };
           statements.push(combinedMatch);
-        } else {
+        } else if (matches.length > 0) {
           matches.forEach((match) => {
             // Add 'type' property to each match
             match.type = "detectedStep";

--- a/src/utils.js
+++ b/src/utils.js
@@ -584,6 +584,10 @@ async function parseContent({ config, content, filePath, fileType }) {
   });
 
   tests.forEach((test) => {
+    // If any steps are unsafe, mark the test as unsafe
+    test.unsafe = isUnsafe({ stepArray: test.steps });
+
+    // Validate test object
     const validation = validate({
       schemaKey: "test_v3",
       object: test,
@@ -601,6 +605,10 @@ async function parseContent({ config, content, filePath, fileType }) {
   });
 
   return tests;
+}
+
+function isUnsafe({ stepArray = [] }) {
+  return stepArray.some((step) => step.unsafe);
 }
 
 // Parse files for tests
@@ -633,6 +641,8 @@ async function parseTests({ config, files }) {
           const cleanup = await readFile({ fileURLOrPath: test.after });
           test.steps = test.steps.concat(cleanup.tests[0].steps);
         }
+        // If any steps are unsafe, mark the test as unsafe
+        test.unsafe = isUnsafe({ stepArray: test.steps });
       }
       // Validate each step
       for (const test of content.tests) {


### PR DESCRIPTION
Introduce a new 'runCode' file type for executing code blocks with improved regex support for multiple languages. Implement safety checks for test steps and enhance version synchronization with the doc-detective-common package. Update configuration merging logic and add tests for markdown code parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for file type inheritance in configuration, allowing custom file types to extend and merge properties from base types.
	- Introduced a new "runCode" markup configuration for markdown, supporting multiple languages and improved code block detection.
	- Tests are now explicitly marked as "unsafe" if any step within them is unsafe.

- **Bug Fixes**
	- Improved error handling in configuration setup by throwing errors instead of exiting the process.

- **Tests**
	- Added comprehensive tests for configuration resolution, file type inheritance, and code block parsing in markdown files.
	- Added test verifying parsing of multiple fenced code blocks in markdown input.

- **Chores**
	- Updated several dependencies to newer versions.
	- Enhanced workflow automation for version management, enabling smarter version syncing with dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->