### PR TITLE
fix: Add XML parsing check for JSON/YAML

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -61,6 +61,10 @@ function parseXmlAttributes({ stringifiedObject }) {
   if (yamlPattern.test(str)) {
     return null;
   }
+  // Check if it looks like a YAML array (starts with '-')
+  if (str.startsWith("-")) {
+    return null;
+  }
 
   // Parse XML-style attributes
   const result = {};


### PR DESCRIPTION
Enhance XML parsing by adding a check to exit when encountering JSON or YAML-like strings. Improve code formatting for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust attribute parsing that detects and skips JSON/YAML-like inputs and normalizes spacing/formatting for attribute values
  * Preserves numeric/boolean typing and nested dot-notation object handling

* **Improvements**
  * Verifies external command availability and reliably creates temporary output directories
  * Non-functional formatting cleanups for readability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->